### PR TITLE
Inspect active comment threads in a PR to determine whether it's actionable

### DIFF
--- a/src/DataSource/AzureDevOpsPullRequestSource.cs
+++ b/src/DataSource/AzureDevOpsPullRequestSource.cs
@@ -177,10 +177,7 @@ namespace PrDash.DataSource
                     // If we there are no active threads where we have participated, the PR is actionable to us.
                     //
                     List<GitPullRequestCommentThread> threads = await client.GetThreadsAsync(pr.Repository.Id, pr.PullRequestId);
-
-                    bool threadInvolvesUs(GitPullRequestCommentThread thread) => thread.Comments.Any(c => Guid.Parse(c.Author.Id) == userId);
-                    bool anyActiveThreads = threads.Any(t => t.Status == CommentThreadStatus.Active && threadInvolvesUs(t));
-                    return anyActiveThreads ? PrState.Waiting : PrState.Actionable;
+                    return threads.Any(t => t.IsActive() && t.InvolvesUser(userId)) ? PrState.Waiting : PrState.Actionable;
                 }
                 else
                 {

--- a/src/DataSource/GitPullRequestCommentThreadExtensions.cs
+++ b/src/DataSource/GitPullRequestCommentThreadExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Linq;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
+
+namespace PrDash.DataSource
+{
+    /// <summary>
+    /// Extension methods for <see cref="GitPullRequestCommentThread"/>
+    /// </summary>
+    internal static class GitPullRequestCommentThreadExtensions
+    {
+        /// <summary>
+        /// Determines if a comment thread involves the specified user.
+        /// </summary>
+        /// <param name="thread">PR comment thread.</param>
+        /// <param name="userId">The GUID of the user to look for.</param>
+        /// <returns>True if the thread involves the user, otherwise false.</returns>
+        public static bool InvolvesUser(this GitPullRequestCommentThread thread, Guid userId) => thread.Comments.Any(c => Guid.Parse(c.Author.Id) == userId);
+
+        /// <summary>
+        /// Determines if a comment thread is active (active or pending).
+        /// </summary>
+        /// <param name="thread">PR comment thread.</param>
+        /// <returns>True is thread status is Active or Pending.</returns>
+        public static bool IsActive(this GitPullRequestCommentThread thread) => thread.Status == CommentThreadStatus.Active || thread.Status == CommentThreadStatus.Pending;
+    }
+}

--- a/src/DataSource/PullRequestStatistics.cs
+++ b/src/DataSource/PullRequestStatistics.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace PrDash.DataSource
 {
     // Ignore warning about not declare visible instance fields.
@@ -37,6 +39,19 @@ namespace PrDash.DataSource
             Waiting = 0;
             SignedOff = 0;
             Drafts = 0;
+        }
+
+        public void Accumulate(PrState? state)
+        {
+            _ = state switch
+            {
+                null => uint.MinValue,
+                PrState.Actionable => Actionable++,
+                PrState.Waiting => Waiting++,
+                PrState.SignedOff => SignedOff++,
+                PrState.Drafts => Drafts++,
+                _ => throw new ArgumentException("Unknown pr state: " + state)
+            };
         }
     }
 

--- a/src/DataSource/PullRequestStatistics.cs
+++ b/src/DataSource/PullRequestStatistics.cs
@@ -41,6 +41,10 @@ namespace PrDash.DataSource
             Drafts = 0;
         }
 
+        /// <summary>
+        /// Accumulate a PR status in this statistics object.
+        /// </summary>
+        /// <param name="state">Status of the PR to accumulate. Can be null for no accumulation.</param>
         public void Accumulate(PrState? state)
         {
             _ = state switch


### PR DESCRIPTION
PR authors are not always diligent about resetting "Waiting" votes after addressing comments, so it's easy to miss actionable PRs we are waiting on.

This change inspects comment threads in PRs we are waiting on. If there are no active comment threads we have participated in, the PR is considered actionable even though our status is waiting.