### PR TITLE
Bugfixes for comment thread tracking

### DIFF
--- a/src/DataSource/AzureDevOpsPullRequestSource.cs
+++ b/src/DataSource/AzureDevOpsPullRequestSource.cs
@@ -176,8 +176,8 @@ namespace PrDash.DataSource
                     // If we have left a comment in a thread that is still active, the PR is not actionable to us.
                     // If we there are no active threads where we have participated, the PR is actionable to us.
                     //
-                    List<GitPullRequestCommentThread> threads = await client.GetThreadsAsync(pr.Repository.Id, pr.PullRequestId);
-                    return threads.Any(t => t.IsActive() && t.InvolvesUser(userId)) ? PrState.Waiting : PrState.Actionable;
+                    List<GitPullRequestCommentThread> threads = await client.GetThreadsAsync(pr.Repository.Id, pr.PullRequestId).ConfigureAwait(false);
+                    return threads.Any(t => t.Status == CommentThreadStatus.Active && t.InvolvesUser(userId)) ? PrState.Waiting : PrState.Actionable;
                 }
                 else
                 {

--- a/src/DataSource/GitPullRequestCommentThreadExtensions.cs
+++ b/src/DataSource/GitPullRequestCommentThreadExtensions.cs
@@ -12,16 +12,11 @@ namespace PrDash.DataSource
         /// <summary>
         /// Determines if a comment thread involves the specified user.
         /// </summary>
+        /// <remarks>ADO can have comments with 'null' content that isn't displayed in the UI but returned by the API. Suspect it's for deleted threads, so exclude those.</remarks>
         /// <param name="thread">PR comment thread.</param>
         /// <param name="userId">The GUID of the user to look for.</param>
         /// <returns>True if the thread involves the user, otherwise false.</returns>
-        public static bool InvolvesUser(this GitPullRequestCommentThread thread, Guid userId) => thread.Comments.Any(c => Guid.Parse(c.Author.Id) == userId);
-
-        /// <summary>
-        /// Determines if a comment thread is active (active or pending).
-        /// </summary>
-        /// <param name="thread">PR comment thread.</param>
-        /// <returns>True is thread status is Active or Pending.</returns>
-        public static bool IsActive(this GitPullRequestCommentThread thread) => thread.Status == CommentThreadStatus.Active || thread.Status == CommentThreadStatus.Pending;
+        public static bool InvolvesUser(this GitPullRequestCommentThread thread, Guid userId) =>
+            thread.Comments.Any(c => !string.IsNullOrWhiteSpace(c.Content) && Guid.Parse(c.Author.Id) == userId);
     }
 }


### PR DESCRIPTION
- ADO APIs sometimes returns 'hidden' comment threads that are not displayed in the UI, where the comment `Content` is _null_. I suspect it's for deleted threads. So exclude those when checking if any active comment threads involving the reviewer is left.
- Remove "Pending" threads from the check and consider only "Active" ones. If a PR has only "Pending" threads involving the reviewer, it could be that the PR author has not resolved the thread but is waiting for additional information from the reviewer. In that case, the PR is actionable.